### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/early-pears-joke.md
+++ b/.changeset/early-pears-joke.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-add-component-signatures": minor
+---
+
+Fixed lint errors

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,13 +13,4 @@ export default [
     ],
   },
   ...baseConfiguration,
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
 ];

--- a/src/utils/analyze-project/find-arguments.ts
+++ b/src/utils/analyze-project/find-arguments.ts
@@ -14,34 +14,28 @@ function analyzeClass(file: string | undefined): Set<string> {
   const traverse = ASTJavaScript.traverse(true);
 
   traverse(file, {
-    visitMemberExpression(node) {
-      this.traverse(node);
+    visitMemberExpression(path) {
+      this.traverse(path);
 
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.object.type !== 'MemberExpression' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.object.property.type !== 'Identifier' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.object.property.name !== 'args'
+        path.node.object.type !== 'MemberExpression' ||
+        path.node.object.property.type !== 'Identifier' ||
+        path.node.object.property.name !== 'args'
       ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.property.type) {
+      switch (path.node.property.type) {
         // Matches the pattern `this.args.someArgument`
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          args.add(node.value.property.name as string);
+          args.add(path.node.property.name);
 
           break;
         }
 
         // Matches the pattern `this.args['someArgument']`
         case 'StringLiteral': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          args.add(node.value.property.value as string);
+          args.add(path.node.property.value);
 
           break;
         }
@@ -50,21 +44,16 @@ function analyzeClass(file: string | undefined): Set<string> {
       return false;
     },
 
-    visitVariableDeclarator(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const { id: leftHandSide, init: rightHandSide } = node.value;
+    visitVariableDeclarator(path) {
+      const { id: leftHandSide, init: rightHandSide } = path.node;
       let isValid = false;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (rightHandSide?.type) {
         // Matches the pattern `const { someArgument } = this.args;`
         case 'MemberExpression': {
           if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.object.type !== 'ThisExpression' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.property.type !== 'Identifier' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.property.name !== 'args'
           ) {
             break;
@@ -78,13 +67,9 @@ function analyzeClass(file: string | undefined): Set<string> {
         // Matches the pattern `const { someArgument } = this.args as SomeType;`
         case 'TSAsExpression': {
           if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.type !== 'MemberExpression' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.object.type !== 'ThisExpression' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.property.type !== 'Identifier' ||
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.property.name !== 'args'
           ) {
             break;
@@ -100,22 +85,23 @@ function analyzeClass(file: string | undefined): Set<string> {
         return false;
       }
 
-      // @ts-expect-error: Incorrect type
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      if (leftHandSide.type !== 'ObjectPattern') {
+        return false;
+      }
+
       leftHandSide.properties.forEach((property) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (property.type !== 'ObjectProperty') {
+          return;
+        }
+
         switch (property.key.type) {
           case 'Identifier': {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            args.add(property.key.name as string);
-
+            args.add(property.key.name);
             break;
           }
 
           case 'StringLiteral': {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            args.add(property.key.value as string);
-
+            args.add(property.key.value);
             break;
           }
         }

--- a/src/utils/analyze-project/find-arguments.ts
+++ b/src/utils/analyze-project/find-arguments.ts
@@ -18,16 +18,21 @@ function analyzeClass(file: string | undefined): Set<string> {
       this.traverse(node);
 
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.object.type !== 'MemberExpression' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.object.property.type !== 'Identifier' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.object.property.name !== 'args'
       ) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.property.type) {
         // Matches the pattern `this.args.someArgument`
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           args.add(node.value.property.name as string);
 
           break;
@@ -35,6 +40,7 @@ function analyzeClass(file: string | undefined): Set<string> {
 
         // Matches the pattern `this.args['someArgument']`
         case 'StringLiteral': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           args.add(node.value.property.value as string);
 
           break;
@@ -45,15 +51,20 @@ function analyzeClass(file: string | undefined): Set<string> {
     },
 
     visitVariableDeclarator(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const { id: leftHandSide, init: rightHandSide } = node.value;
       let isValid = false;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (rightHandSide?.type) {
         // Matches the pattern `const { someArgument } = this.args;`
         case 'MemberExpression': {
           if (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.object.type !== 'ThisExpression' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.property.type !== 'Identifier' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.property.name !== 'args'
           ) {
             break;
@@ -67,9 +78,13 @@ function analyzeClass(file: string | undefined): Set<string> {
         // Matches the pattern `const { someArgument } = this.args as SomeType;`
         case 'TSAsExpression': {
           if (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.type !== 'MemberExpression' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.object.type !== 'ThisExpression' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.property.type !== 'Identifier' ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             rightHandSide.expression.property.name !== 'args'
           ) {
             break;
@@ -85,16 +100,20 @@ function analyzeClass(file: string | undefined): Set<string> {
         return false;
       }
 
-      // @ts-expect-error: Assume that types from external packages are correct
+      // @ts-expect-error: Incorrect type
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       leftHandSide.properties.forEach((property) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (property.key.type) {
           case 'Identifier': {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             args.add(property.key.name as string);
 
             break;
           }
 
           case 'StringLiteral': {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             args.add(property.key.value as string);
 
             break;

--- a/src/utils/analyze-project/find-blocks.ts
+++ b/src/utils/analyze-project/find-blocks.ts
@@ -24,7 +24,8 @@ export function findBlocks(templateFile: string): Signature['Blocks'] {
         return key === 'to';
       });
 
-      // @ts-expect-error: Assume that types from external packages are correct
+      // @ts-expect-error: Incorrect type
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const blockName = normalizeBlockName(toArgument?.value.original);
 
       const positionalArgumentTypes = node.params.map(

--- a/src/utils/analyze-project/find-blocks.ts
+++ b/src/utils/analyze-project/find-blocks.ts
@@ -24,9 +24,10 @@ export function findBlocks(templateFile: string): Signature['Blocks'] {
         return key === 'to';
       });
 
-      // @ts-expect-error: Incorrect type
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const blockName = normalizeBlockName(toArgument?.value.original);
+      const blockName = normalizeBlockName(
+        // @ts-expect-error: Incorrect type
+        toArgument?.value?.original as string | undefined,
+      );
 
       const positionalArgumentTypes = node.params.map(
         ({ type: recastType }) => {

--- a/src/utils/create-registries/create-registry.ts
+++ b/src/utils/create-registries/create-registry.ts
@@ -13,7 +13,8 @@ export function createRegistry(file: string, data: Data): string {
 
   const ast = traverse(file);
 
-  // @ts-expect-error: Assume that types from external packages are correct
+  // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
   const nodes = ast.program.body;
 
   const registryEntries = AST.builders.tsInterfaceBody([
@@ -49,6 +50,7 @@ export function createRegistry(file: string, data: Data): string {
 
   registryNode.declare = true;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   nodes.push(registryNode);
 
   return AST.print(ast);

--- a/src/utils/create-registries/create-registry.ts
+++ b/src/utils/create-registries/create-registry.ts
@@ -13,10 +13,6 @@ export function createRegistry(file: string, data: Data): string {
 
   const ast = traverse(file);
 
-  // @ts-expect-error: Incorrect type
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-  const nodes = ast.program.body;
-
   const registryEntries = AST.builders.tsInterfaceBody([
     AST.builders.tsPropertySignature(
       AST.builders.stringLiteral(data.entity.doubleColonizedName),
@@ -50,8 +46,9 @@ export function createRegistry(file: string, data: Data): string {
 
   registryNode.declare = true;
 
+  // @ts-expect-error: Incorrect type
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-  nodes.push(registryNode);
+  ast.program.body.push(registryNode);
 
   return AST.print(ast);
 }

--- a/src/utils/create-registries/rename-component/update-references.ts
+++ b/src/utils/create-registries/rename-component/update-references.ts
@@ -33,6 +33,7 @@ export function updateReferences(file: string, options: Options): string {
             ),
           ];
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           path.parentPath.value.push(...nodesToAdd);
 
           return AST.builders.variableDeclaration('const', [

--- a/src/utils/create-signatures/create-signature/builders.ts
+++ b/src/utils/create-signatures/create-signature/builders.ts
@@ -5,7 +5,7 @@ export function builderConvertArgsToSignature(nodes: unknown[] = []) {
   return [
     AST.builders.tsPropertySignature(
       AST.builders.identifier('Args'),
-      // @ts-expect-error: Assume that types from external packages are correct
+      // @ts-expect-error: Incorrect type
       AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(nodes)),
       false,
     ),
@@ -16,7 +16,7 @@ export function builderConvertArgsToSignature(nodes: unknown[] = []) {
 export function builderCreateSignature(identifier: string, members: unknown[]) {
   return AST.builders.tsInterfaceDeclaration(
     AST.builders.identifier(identifier),
-    // @ts-expect-error: Assume that types from external packages are correct
+    // @ts-expect-error: Incorrect type
     AST.builders.tsInterfaceBody(members),
   );
 }

--- a/src/utils/create-signatures/create-signature/builders.ts
+++ b/src/utils/create-signatures/create-signature/builders.ts
@@ -1,28 +1,38 @@
 import { AST } from '@codemod-utils/ast-javascript';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderConvertArgsToSignature(nodes: unknown[] = []) {
+type InterfaceDeclaration = ReturnType<
+  typeof AST.builders.tsInterfaceDeclaration
+>;
+
+type PropertySignature = ReturnType<typeof AST.builders.tsPropertySignature>;
+
+type TypeParameters = ReturnType<
+  typeof AST.builders.tsTypeParameterInstantiation
+>;
+
+export function builderConvertArgsToSignature(
+  nodes: Parameters<typeof AST.builders.tsTypeLiteral>[0] = [],
+): PropertySignature[] {
   return [
     AST.builders.tsPropertySignature(
       AST.builders.identifier('Args'),
-      // @ts-expect-error: Incorrect type
       AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(nodes)),
       false,
     ),
   ];
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderCreateSignature(identifier: string, members: unknown[]) {
+export function builderCreateSignature(
+  identifier: string,
+  members: Parameters<typeof AST.builders.tsInterfaceBody>[0],
+): InterfaceDeclaration {
   return AST.builders.tsInterfaceDeclaration(
     AST.builders.identifier(identifier),
-    // @ts-expect-error: Incorrect type
     AST.builders.tsInterfaceBody(members),
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderPassSignature(identifier: string) {
+export function builderPassSignature(identifier: string): TypeParameters {
   return AST.builders.tsTypeParameterInstantiation([
     AST.builders.tsTypeReference(AST.builders.identifier(identifier)),
   ]);

--- a/src/utils/create-signatures/create-signature/pass-signature-to-base-component.ts
+++ b/src/utils/create-signatures/create-signature/pass-signature-to-base-component.ts
@@ -7,7 +7,9 @@ import {
 } from './builders.js';
 import { isSignature } from './is-signature.js';
 
-const MARKER = 'template_fd9b2463e5f141cfb5666b64daa1f11a';
+type TypeParameters = ReturnType<
+  typeof AST.builders.tsTypeParameterInstantiation
+>;
 
 type Options = {
   baseComponentName: string;
@@ -36,31 +38,31 @@ export function passSignatureToBaseComponent(
         return false;
       }
 
-      let typeParameters;
+      let typeParameters: TypeParameters | undefined;
 
       switch (path.node.callee.name) {
         case 'templateOnlyComponent': {
           // @ts-expect-error: Incorrect type
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          typeParameters = path.node.typeParameters;
+          typeParameters = path.node.typeParameters as TypeParameters;
+
           break;
         }
 
-        case MARKER: {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const type = path.parentPath.value.type;
+        case 'template_fd9b2463e5f141cfb5666b64daa1f11a': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const parentPath = path.parentPath;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          const type = parentPath.value.type as string;
 
           if (type === 'TSSatisfiesExpression') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             typeParameters =
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              path.parentPath.value.typeAnnotation.typeParameters;
+              parentPath.value.typeAnnotation.typeParameters as TypeParameters;
           } else if (type === 'VariableDeclarator') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             typeParameters =
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              path.parentPath.value.id.typeAnnotation.typeAnnotation
-                .typeParameters;
+              parentPath.value.id.typeAnnotation.typeAnnotation
+                .typeParameters as TypeParameters;
           }
 
           break;
@@ -79,12 +81,15 @@ export function passSignatureToBaseComponent(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
-            const identifier = `${data.entity.pascalizedName}Signature`;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            const index = path.parentPath.name;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const parentPath = path.parentPath;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            path.parentPath.parentPath.value.splice(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const index = parentPath.name as number;
+            const identifier = `${data.entity.pascalizedName}Signature`;
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (parentPath.parentPath.value as unknown[]).splice(
               index,
               0,
               builderCreateSignature(identifier, members),
@@ -97,12 +102,15 @@ export function passSignatureToBaseComponent(
           }
 
           case 'VariableDeclarator': {
-            const identifier = `${data.entity.pascalizedName}Signature`;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            const index = path.parentPath.parentPath.parentPath.name;
+            const parentPath = path.parentPath.parentPath.parentPath;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            path.parentPath.parentPath.parentPath.parentPath.value.splice(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const index = parentPath.name as number;
+            const identifier = `${data.entity.pascalizedName}Signature`;
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (parentPath.parentPath.value as unknown[]).splice(
               index,
               0,
               builderCreateSignature(identifier, members),
@@ -118,32 +126,29 @@ export function passSignatureToBaseComponent(
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const typeParameter = typeParameters.params[0]!;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const members = isSignature(typeParameter.members)
-            ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              typeParameter.members
-            : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-              builderConvertArgsToSignature(typeParameter.members);
+            ? typeParameter.members
+            : builderConvertArgsToSignature(typeParameter.members);
 
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           switch (path.parentPath.node.type) {
             case 'ExportDefaultDeclaration': {
-              const identifier = `${data.entity.pascalizedName}Signature`;
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-              const index = path.parentPath.name;
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              const parentPath = path.parentPath;
 
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-              path.parentPath.parentPath.value.splice(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              const index = parentPath.name as number;
+              const identifier = `${data.entity.pascalizedName}Signature`;
+
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              (parentPath.parentPath.value as unknown[]).splice(
                 index,
                 0,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 builderCreateSignature(identifier, members),
               );
 
@@ -154,15 +159,17 @@ export function passSignatureToBaseComponent(
             }
 
             case 'VariableDeclarator': {
-              const identifier = `${data.entity.pascalizedName}Signature`;
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-              const index = path.parentPath.parentPath.parentPath.name;
+              const parentPath = path.parentPath.parentPath.parentPath;
 
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-              path.parentPath.parentPath.parentPath.parentPath.value.splice(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              const index = parentPath.name as number;
+              const identifier = `${data.entity.pascalizedName}Signature`;
+
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              (parentPath.parentPath.value as unknown[]).splice(
                 index,
                 0,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 builderCreateSignature(identifier, members),
               );
 
@@ -178,12 +185,12 @@ export function passSignatureToBaseComponent(
 
         // When the interface is defined "outside"
         case 'TSTypeReference': {
-          const identifier = `${data.entity.pascalizedName}Signature`;
+          if (typeParameter.typeName.type === 'Identifier') {
+            const identifier = `${data.entity.pascalizedName}Signature`;
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          interfaceName = typeParameter.typeName.name;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          typeParameter.typeName.name = identifier;
+            interfaceName = typeParameter.typeName.name;
+            typeParameter.typeName.name = identifier;
+          }
 
           return false;
         }
@@ -210,12 +217,12 @@ export function passSignatureToBaseComponent(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const index = path.parentPath.name as number;
             const identifier = `${data.entity.pascalizedName}Signature`;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            const index = path.parentPath.name;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            path.parentPath.parentPath.value.splice(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (path.parentPath.parentPath.value as unknown[]).splice(
               index,
               0,
               builderCreateSignature(identifier, members),
@@ -227,12 +234,11 @@ export function passSignatureToBaseComponent(
           }
 
           case 'Program': {
+            const index = path.name as number;
             const identifier = `${data.entity.pascalizedName}Signature`;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const index = path.name;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            path.parentPath.value.splice(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (path.parentPath.value as unknown[]).splice(
               index,
               0,
               builderCreateSignature(identifier, members),
@@ -252,16 +258,18 @@ export function passSignatureToBaseComponent(
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const parentPath = path.parentPath;
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          const index = parentPath.name as number;
+          const identifier = `${data.entity.pascalizedName}Signature`;
           const members = isSignature(typeParameter.members)
             ? typeParameter.members
             : builderConvertArgsToSignature(typeParameter.members);
 
-          const identifier = `${data.entity.pascalizedName}Signature`;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const index = path.parentPath.name;
-
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          path.parentPath.parentPath.value.splice(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (parentPath.parentPath.value as unknown[]).splice(
             index,
             0,
             builderCreateSignature(identifier, members),
@@ -292,8 +300,7 @@ export function passSignatureToBaseComponent(
 
     visitClassExpression(path) {
       if (
-        !path.node.superClass ||
-        path.node.superClass.type !== 'Identifier' ||
+        path.node.superClass?.type !== 'Identifier' ||
         path.node.superClass.name !== baseComponentName
       ) {
         return false;
@@ -302,17 +309,19 @@ export function passSignatureToBaseComponent(
       const typeParameters = path.node.superTypeParameters;
 
       if (!typeParameters) {
-        const members = builderConvertArgsToSignature();
-
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'VariableDeclarator': {
-            const identifier = `${data.entity.pascalizedName}Signature`;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            const index = path.parentPath.parentPath.parentPath.name;
+            const parentPath = path.parentPath.parentPath.parentPath;
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            path.parentPath.parentPath.parentPath.parentPath.value.splice(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            const index = parentPath.name as number;
+            const identifier = `${data.entity.pascalizedName}Signature`;
+            const members = builderConvertArgsToSignature();
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (parentPath.parentPath.value as unknown[]).splice(
               index,
               0,
               builderCreateSignature(identifier, members),
@@ -332,16 +341,18 @@ export function passSignatureToBaseComponent(
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          const parentPath = path.parentPath.parentPath.parentPath;
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          const index = parentPath.name as number;
+          const identifier = `${data.entity.pascalizedName}Signature`;
           const members = isSignature(typeParameter.members)
             ? typeParameter.members
             : builderConvertArgsToSignature(typeParameter.members);
 
-          const identifier = `${data.entity.pascalizedName}Signature`;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const index = path.parentPath.parentPath.parentPath.name;
-
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          path.parentPath.parentPath.parentPath.parentPath.value.splice(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (parentPath.parentPath.value as unknown[]).splice(
             index,
             0,
             builderCreateSignature(identifier, members),

--- a/src/utils/create-signatures/create-signature/pass-signature-to-base-component.ts
+++ b/src/utils/create-signatures/create-signature/pass-signature-to-base-component.ts
@@ -40,19 +40,25 @@ export function passSignatureToBaseComponent(
 
       switch (path.node.callee.name) {
         case 'templateOnlyComponent': {
-          // @ts-expect-error: Assume that types from external packages are correct
+          // @ts-expect-error: Incorrect type
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           typeParameters = path.node.typeParameters;
           break;
         }
 
         case MARKER: {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const type = path.parentPath.value.type;
 
           if (type === 'TSSatisfiesExpression') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             typeParameters =
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               path.parentPath.value.typeAnnotation.typeParameters;
           } else if (type === 'VariableDeclarator') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             typeParameters =
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               path.parentPath.value.id.typeAnnotation.typeAnnotation
                 .typeParameters;
           }
@@ -70,18 +76,21 @@ export function passSignatureToBaseComponent(
       if (!typeParameters) {
         const members = builderConvertArgsToSignature();
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
             const identifier = `${data.entity.pascalizedName}Signature`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             const index = path.parentPath.name;
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             path.parentPath.parentPath.value.splice(
               index,
               0,
               builderCreateSignature(identifier, members),
             );
 
-            // @ts-expect-error: Assume that types from external packages are correct
+            // @ts-expect-error: Incorrect type
             path.node.typeParameters = builderPassSignature(identifier);
 
             break;
@@ -89,15 +98,17 @@ export function passSignatureToBaseComponent(
 
           case 'VariableDeclarator': {
             const identifier = `${data.entity.pascalizedName}Signature`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             const index = path.parentPath.parentPath.parentPath.name;
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             path.parentPath.parentPath.parentPath.parentPath.value.splice(
               index,
               0,
               builderCreateSignature(identifier, members),
             );
 
-            // @ts-expect-error: Assume that types from external packages are correct
+            // @ts-expect-error: Incorrect type
             path.node.typeParameters = builderPassSignature(identifier);
 
             break;
@@ -107,27 +118,36 @@ export function passSignatureToBaseComponent(
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const typeParameter = typeParameters.params[0]!;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (typeParameter.type) {
         // When the interface is directly passed to the component
         case 'TSTypeLiteral': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const members = isSignature(typeParameter.members)
-            ? typeParameter.members
-            : builderConvertArgsToSignature(typeParameter.members);
+            ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              typeParameter.members
+            : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+              builderConvertArgsToSignature(typeParameter.members);
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           switch (path.parentPath.node.type) {
             case 'ExportDefaultDeclaration': {
               const identifier = `${data.entity.pascalizedName}Signature`;
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
               const index = path.parentPath.name;
 
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
               path.parentPath.parentPath.value.splice(
                 index,
                 0,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 builderCreateSignature(identifier, members),
               );
 
-              // @ts-expect-error: Assume that types from external packages are correct
+              // @ts-expect-error: Incorrect type
               path.node.typeParameters = builderPassSignature(identifier);
 
               break;
@@ -135,15 +155,18 @@ export function passSignatureToBaseComponent(
 
             case 'VariableDeclarator': {
               const identifier = `${data.entity.pascalizedName}Signature`;
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
               const index = path.parentPath.parentPath.parentPath.name;
 
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
               path.parentPath.parentPath.parentPath.parentPath.value.splice(
                 index,
                 0,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 builderCreateSignature(identifier, members),
               );
 
-              // @ts-expect-error: Assume that types from external packages are correct
+              // @ts-expect-error: Incorrect type
               path.node.typeParameters = builderPassSignature(identifier);
 
               break;
@@ -157,7 +180,9 @@ export function passSignatureToBaseComponent(
         case 'TSTypeReference': {
           const identifier = `${data.entity.pascalizedName}Signature`;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           interfaceName = typeParameter.typeName.name;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           typeParameter.typeName.name = identifier;
 
           return false;
@@ -182,11 +207,14 @@ export function passSignatureToBaseComponent(
       if (!typeParameters) {
         const members = builderConvertArgsToSignature();
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'ExportDefaultDeclaration': {
             const identifier = `${data.entity.pascalizedName}Signature`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             const index = path.parentPath.name;
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             path.parentPath.parentPath.value.splice(
               index,
               0,
@@ -200,8 +228,10 @@ export function passSignatureToBaseComponent(
 
           case 'Program': {
             const identifier = `${data.entity.pascalizedName}Signature`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const index = path.name;
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             path.parentPath.value.splice(
               index,
               0,
@@ -227,8 +257,10 @@ export function passSignatureToBaseComponent(
             : builderConvertArgsToSignature(typeParameter.members);
 
           const identifier = `${data.entity.pascalizedName}Signature`;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const index = path.parentPath.name;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           path.parentPath.parentPath.value.splice(
             index,
             0,
@@ -272,11 +304,14 @@ export function passSignatureToBaseComponent(
       if (!typeParameters) {
         const members = builderConvertArgsToSignature();
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         switch (path.parentPath.node.type) {
           case 'VariableDeclarator': {
             const identifier = `${data.entity.pascalizedName}Signature`;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             const index = path.parentPath.parentPath.parentPath.name;
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
             path.parentPath.parentPath.parentPath.parentPath.value.splice(
               index,
               0,
@@ -302,8 +337,10 @@ export function passSignatureToBaseComponent(
             : builderConvertArgsToSignature(typeParameter.members);
 
           const identifier = `${data.entity.pascalizedName}Signature`;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const index = path.parentPath.parentPath.parentPath.name;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           path.parentPath.parentPath.parentPath.parentPath.value.splice(
             index,
             0,

--- a/src/utils/update-signatures/update-signature.ts
+++ b/src/utils/update-signatures/update-signature.ts
@@ -16,13 +16,15 @@ type Data = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function getBodyNode(node: unknown, key: 'Args' | 'Blocks' | 'Element') {
-  // @ts-expect-error: Assume that types from external packages are correct
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
   return node.body.body.find((node) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (node.type !== 'TSPropertySignature' || node.key.type !== 'Identifier') {
       return false;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return node.key.name === key;
   });
 }
@@ -41,21 +43,28 @@ export function updateSignature(file: string, data: Data): string {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const argsNode = getBodyNode(path.node, 'Args');
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const isArgsKnown =
         argsNode &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         argsNode.typeAnnotation.typeAnnotation.type === 'TSTypeLiteral' &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         argsNode.typeAnnotation.typeAnnotation.members.length > 0;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ArgsNode = isArgsKnown
         ? argsNode
         : builderCreateArgsNode(data.signature);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const BlocksNode =
         getBodyNode(path.node, 'Blocks') ??
         builderCreateBlocksNode(data.signature);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ElementNode =
         getBodyNode(path.node, 'Element') ??
         builderCreateElementNode(data.signature);
@@ -63,6 +72,7 @@ export function updateSignature(file: string, data: Data): string {
       return AST.builders.tsInterfaceDeclaration(
         AST.builders.identifier(identifier),
         AST.builders.tsInterfaceBody(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           [ArgsNode, BlocksNode, ElementNode].filter(Boolean),
         ),
       );

--- a/src/utils/update-signatures/update-signature.ts
+++ b/src/utils/update-signatures/update-signature.ts
@@ -7,6 +7,10 @@ import {
   builderCreateElementNode,
 } from './update-signature/builders.js';
 
+type InterfaceDeclaration = ReturnType<
+  typeof AST.builders.tsInterfaceDeclaration
+>;
+
 type Data = {
   entity: {
     pascalizedName: string;
@@ -15,16 +19,15 @@ type Data = {
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function getBodyNode(node: unknown, key: 'Args' | 'Blocks' | 'Element') {
-  // @ts-expect-error: Incorrect type
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+function getBodyNode(
+  node: InterfaceDeclaration,
+  key: 'Args' | 'Blocks' | 'Element',
+) {
   return node.body.body.find((node) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (node.type !== 'TSPropertySignature' || node.key.type !== 'Identifier') {
       return false;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return node.key.name === key;
   });
 }
@@ -43,28 +46,20 @@ export function updateSignature(file: string, data: Data): string {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const argsNode = getBodyNode(path.node, 'Args');
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const isArgsKnown =
-        argsNode &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        argsNode.typeAnnotation.typeAnnotation.type === 'TSTypeLiteral' &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        argsNode?.typeAnnotation?.typeAnnotation?.type === 'TSTypeLiteral' &&
         argsNode.typeAnnotation.typeAnnotation.members.length > 0;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ArgsNode = isArgsKnown
         ? argsNode
         : builderCreateArgsNode(data.signature);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const BlocksNode =
         getBodyNode(path.node, 'Blocks') ??
         builderCreateBlocksNode(data.signature);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const ElementNode =
         getBodyNode(path.node, 'Element') ??
         builderCreateElementNode(data.signature);
@@ -72,8 +67,9 @@ export function updateSignature(file: string, data: Data): string {
       return AST.builders.tsInterfaceDeclaration(
         AST.builders.identifier(identifier),
         AST.builders.tsInterfaceBody(
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          [ArgsNode, BlocksNode, ElementNode].filter(Boolean),
+          [ArgsNode, BlocksNode, ElementNode].filter((node) => {
+            return node !== undefined;
+          }),
         ),
       );
     },

--- a/src/utils/update-signatures/update-signature/builders.ts
+++ b/src/utils/update-signatures/update-signature/builders.ts
@@ -53,7 +53,7 @@ export function builderCreateArgsNode(signature: Signature) {
 
   return AST.builders.tsPropertySignature(
     AST.builders.identifier('Args'),
-    // @ts-expect-error: Assume that types from external packages are correct
+    // @ts-expect-error: Incorrect type
     AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(members)),
     false,
   );
@@ -84,7 +84,7 @@ export function builderCreateBlocksNode(signature: Signature) {
 
   return AST.builders.tsPropertySignature(
     AST.builders.identifier('Blocks'),
-    // @ts-expect-error: Assume that types from external packages are correct
+    // @ts-expect-error: Incorrect type
     AST.builders.tsTypeAnnotation(AST.builders.tsTypeLiteral(members)),
     false,
   );

--- a/src/utils/update-signatures/update-signature/builders.ts
+++ b/src/utils/update-signatures/update-signature/builders.ts
@@ -2,6 +2,8 @@ import { AST } from '@codemod-utils/ast-javascript';
 
 import type { Signature } from '../../../types/index.js';
 
+type PropertySignature = ReturnType<typeof AST.builders.tsPropertySignature>;
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function builderConvertTsTypeToKeyword(tsType: string) {
   switch (tsType) {
@@ -36,8 +38,7 @@ function needsQuotations(key: string): boolean {
   return key.includes('-');
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderCreateArgsNode(signature: Signature) {
+export function builderCreateArgsNode(signature: Signature): PropertySignature {
   const members: unknown[] = [];
 
   (signature.Args ?? []).forEach((argumentName) => {
@@ -59,10 +60,11 @@ export function builderCreateArgsNode(signature: Signature) {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderCreateBlocksNode(signature: Signature) {
+export function builderCreateBlocksNode(
+  signature: Signature,
+): PropertySignature | undefined {
   if (signature.Blocks === undefined) {
-    return;
+    return undefined;
   }
 
   const members: unknown[] = [];
@@ -90,10 +92,11 @@ export function builderCreateBlocksNode(signature: Signature) {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function builderCreateElementNode(signature: Signature) {
+export function builderCreateElementNode(
+  signature: Signature,
+): PropertySignature | undefined {
   if (signature.Element === undefined) {
-    return;
+    return undefined;
   }
 
   return AST.builders.tsPropertySignature(


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
